### PR TITLE
Use Windows Server 2025

### DIFF
--- a/cloud-gaming-on-ec2-using-steam.yaml
+++ b/cloud-gaming-on-ec2-using-steam.yaml
@@ -51,7 +51,7 @@ Parameters:
   imageId:
     Description: AMI ID ( aws ssm get-parameters-by-path --path /aws/service/ami-windows-latest --query "Parameters[].Name" )
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ami-windows-latest/Windows_Server-2019-English-Full-Base
+    Default: /aws/service/ami-windows-latest/Windows_Server-2025-English-Full-Base
 
   ec2Name:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Windows Server 2019 is the equivalent of an out of date version of Windows 10.  Modern AAA games (Jedi Survivor, Assassin's Creed Mirage) error out on startup due to seemingly missing DirectX API bindings.  Update the default to Windows Server 2025 instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
